### PR TITLE
Gate makemigrations behind env var

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -6,7 +6,10 @@ chmod -R 777 /app/data
 
 # Run migrations
 echo "Running migrations..."
-python manage.py makemigrations
+if [ "$RUN_MAKEMIGRATIONS" = "1" ]; then
+  echo "Running makemigrations..."
+  python manage.py makemigrations
+fi
 python manage.py migrate
 
 # Start server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       - DJANGO_DEBUG=True
       - DJANGO_SECRET_KEY=insecure-dev-only-key
+      - RUN_MAKEMIGRATIONS=1
     restart: always
 
 volumes:


### PR DESCRIPTION
## Summary
- avoid accidental makemigrations by default
- only run `makemigrations` when `RUN_MAKEMIGRATIONS=1`
- enable this variable in docker-compose for development

## Testing
- `bash -n backend/start.sh`


------
https://chatgpt.com/codex/tasks/task_e_684445bf13ac8324b4937b0df300f746