### PR TITLE
Fix README naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ docker-compose up --build
 ## 🗄️ Project Structure
 
 ```
-file-hub/
+dplat-file-vault-coding-challenge/
 ├── backend/                # Django backend
 │   ├── files/             # Main application
 │   │   ├── models.py      # Data models


### PR DESCRIPTION
## Summary
- keep project naming consistent

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684445bc24988324b91758eb44baaba6