### PR TITLE
Remove extraneous Zone.Identifier files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*:[Zz]one.Identifier

--- a/README.md:Zone.Identifier
+++ b/README.md:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/Dockerfile:Zone.Identifier
+++ b/backend/Dockerfile:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/README.md:Zone.Identifier
+++ b/backend/README.md:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/core/__init__.py:Zone.Identifier
+++ b/backend/core/__init__.py:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/core/asgi.py:Zone.Identifier
+++ b/backend/core/asgi.py:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/core/settings.py:Zone.Identifier
+++ b/backend/core/settings.py:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/core/urls.py:Zone.Identifier
+++ b/backend/core/urls.py:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/core/wsgi.py:Zone.Identifier
+++ b/backend/core/wsgi.py:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/files/__init__.py:Zone.Identifier
+++ b/backend/files/__init__.py:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/files/apps.py:Zone.Identifier
+++ b/backend/files/apps.py:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/files/migrations/__init__.py:Zone.Identifier
+++ b/backend/files/migrations/__init__.py:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/files/models.py:Zone.Identifier
+++ b/backend/files/models.py:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/files/serializers.py:Zone.Identifier
+++ b/backend/files/serializers.py:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/files/urls.py:Zone.Identifier
+++ b/backend/files/urls.py:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/files/views.py:Zone.Identifier
+++ b/backend/files/views.py:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/manage.py:Zone.Identifier
+++ b/backend/manage.py:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/requirements.txt:Zone.Identifier
+++ b/backend/requirements.txt:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/backend/start.sh:Zone.Identifier
+++ b/backend/start.sh:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/create_submission_zip.py:Zone.Identifier
+++ b/create_submission_zip.py:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip

--- a/docker-compose.yml:Zone.Identifier
+++ b/docker-compose.yml:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\aryan\Downloads\dplat-file-vault-coding-challenge.zip


### PR DESCRIPTION
## Summary
- remove all `*:Zone.Identifier` artifacts
- ignore future Windows Zone.Identifier streams using `.gitignore`

## Testing
- `pytest -q`
- `python backend/manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684445b78914832497d4f583ae07b1dc