### PR TITLE
Fix throttling duration parsing and dedup tests

### DIFF
--- a/backend/files/serializers.py
+++ b/backend/files/serializers.py
@@ -6,6 +6,9 @@ class FileSerializer(serializers.ModelSerializer):
         model = File
         fields = [
             'id', 'file', 'original_filename', 'file_type', 'size',
-            'uploaded_at', 'duplicate_of', 'uploaded_by'
+            'uploaded_at', 'duplicate_of', 'uploaded_by', 'hash'
         ]
         read_only_fields = ['id', 'uploaded_at', 'duplicate_of', 'uploaded_by']
+        extra_kwargs = {
+            'hash': {'write_only': True}
+        }

--- a/backend/files/tests/test_api.py
+++ b/backend/files/tests/test_api.py
@@ -7,7 +7,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from files.models import File
 
 
-@override_settings(MEDIA_ROOT=tempfile.mkdtemp())
+@override_settings(MEDIA_ROOT=tempfile.mkdtemp(), API_CALL_LIMIT=1000, API_CALL_PERIOD=1)
 class FileAPITestCase(APITestCase):
     def test_upload_file(self):
         url = reverse('file-list')

--- a/backend/files/throttling.py
+++ b/backend/files/throttling.py
@@ -2,21 +2,42 @@ from rest_framework.throttling import SimpleRateThrottle
 from django.conf import settings
 
 class UserIdRateThrottle(SimpleRateThrottle):
+    """Throttle class enforcing request limits per custom time window."""
+
     scope = 'user'
 
     def get_cache_key(self, request, view):
-        user_id = request.headers.get('UserId', 'anonymous')
-        if not user_id:
-            user_id = 'anonymous'
+        user_id = request.headers.get('UserId', 'anonymous') or 'anonymous'
         ident = user_id
         return self.cache_format % {
             'scope': self.scope,
-            'ident': ident
+            'ident': ident,
         }
 
     @property
-    def rate(self):
+    def rate(self) -> str:
+        """Return DRF rate string like '5/10s'."""
         calls = getattr(settings, 'API_CALL_LIMIT', 2)
         period = getattr(settings, 'API_CALL_PERIOD', 1)
         return f"{calls}/{period}s"
+
+    def parse_rate(self, rate: str):
+        """Allow numeric second-based durations (e.g. '5/10s')."""
+        if rate is None:
+            return (None, None)
+
+        try:
+            num, period = rate.split('/')
+            num_requests = int(num)
+        except ValueError:
+            return (None, None)
+
+        if period.endswith('s'):
+            try:
+                seconds = int(period[:-1] or '1')
+            except ValueError:
+                return (None, None)
+            return num_requests, seconds
+
+        return super().parse_rate(rate)
 


### PR DESCRIPTION
## Summary
- support numeric second durations in `UserIdRateThrottle`
- include `hash` field in serializer so deduplication works
- prevent rate limits from affecting tests

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6844497c5dfc832491041538f827abb5